### PR TITLE
modern extension name

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
-Package: com.github.ses
-Copyright (C) 2018, Andrei Mondoc <andreimondoc@gmail.com>
+Package: ses
+Copyright (C) 2018, Your Name <you@example.com>
 Licensed under the GNU Affero Public License 3.0 (below).
 
 -------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# com.github.ses
+# ses
 
 ![Screenshot](/images/screenshot.png)
 
@@ -22,7 +22,7 @@ install it with the command-line tool [cv](https://github.com/civicrm/cv).
 
 ```bash
 cd <extension-dir>
-cv dl com.github.ses@https://github.com/FIXME/com.github.ses/archive/master.zip
+cv dl ses@https://github.com/FIXME/ses/archive/master.zip
 ```
 
 ## Installation (CLI, Git)
@@ -31,7 +31,7 @@ Sysadmins and developers may clone the [Git](https://en.wikipedia.org/wiki/Git) 
 install it with the command-line tool [cv](https://github.com/civicrm/cv).
 
 ```bash
-git clone https://github.com/FIXME/com.github.ses.git
+git clone https://github.com/FIXME/ses.git
 cv en ses
 ```
 

--- a/info.xml
+++ b/info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<extension key="com.github.ses" type="module">
+<extension key="ses" type="module">
   <file>ses</file>
   <name>Amazon SES (Simple Email Service)</name>
   <description>This extension (for now) porcesses bounces from Amazon SES through Amazon SNS service.</description>
@@ -9,9 +9,9 @@
     <email>andreimondoc@gmail.com</email>
   </maintainer>
   <urls>
-    <url desc="Main Extension Page">https://github.com/mecachisenros/com.github.com</url>
-    <url desc="Documentation">https://github.com/mecachisenros/com.github.com</url>
-    <url desc="Support">https://github.com/mecachisenros/com.github.com/issues</url>
+    <url desc="Main Extension Page">https://github.com/mecachisenros/civicrm-ses</url>
+    <url desc="Documentation">https://github.com/mecachisenros/civicrm-ses</url>
+    <url desc="Support">https://github.com/mecachisenros/civicrm-ses</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2018-04-30</releaseDate>

--- a/ses.civix.php
+++ b/ses.civix.php
@@ -8,7 +8,7 @@
  */
 class CRM_Ses_ExtensionUtil {
   const SHORT_NAME = "ses";
-  const LONG_NAME = "com.github.ses";
+  const LONG_NAME = "ses";
   const CLASS_PREFIX = "CRM_Ses";
 
   /**


### PR DESCRIPTION
Hey there,

Here is a PR that uses the new extension name convention.

I've called it ses.

My suggestion for repo name would be `civicrm-ses` (I think the `civicrm-` 'namespace' convention is a 
good one) and I have updated the info.xml github links to work for that URL but what you call it is totally up to you of course.

FYI, I think that in most cases, the mechanics of the renaming is fairly easy. You can do something like
```
civix generate:module <newname>
cp -pr <newname>/* <extension-repo>
```
Followed by appropriate incantations of `git status`, `git diff`, `git add`, etc.

It gets trickier if your extension manages entities (and we might need a special upgrade script or similar to handle that) but it isn't necessary in this case, I don't think.